### PR TITLE
Ci build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,31 +23,21 @@ jobs:
 
       - name: Prepare Jython Environment
         run: >-
-          # Create a virtualenv for Ghidra packages.
-          # It is important to use Python2.7 for this venv!
-          # If you want, you can skip this step and use your default Python installation.
           mkvirtualenv -p python2.7 ghidra
-
-          # Create Jython's site-pacakges directory.
           jython_site_packages=~/.local/lib/jython2.7/site-packages
           mkdir -p $jython_site_packages
-
-          # Create a PTH file to point Jython to Python's site-packages directories.
-          # Again, this has to be Python2.7.
-
-          # Outside a virtualenv, use
           python2.7 -c "import site; print(site.getusersitepackages()); print(site.getsitepackages()[-1])" > $jython_site_packages/python.pth
-
-          # If using virtualenv, use the following instead
-          python2.7 -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())" > $jython_site_packages/python.pth
-
-
-          # Use pip to install packages for Ghidra
-          pip install attrs typing
+          pip2.7 install attrs typing
 
       - name: Build Package
         run: >-
           "$GHIDRA_INSTALL_DIR/support/analyzeHeadless" /tmp tmp -scriptPath $(pwd) -preScript generate_ghidra_pyi.py ./ ${{ github.ref }}
+
+      - name: Check Package Results # analyzeHeadless doesn't return with a nonzero exit code on script failure
+        run: >-
+          test -f setup.py
+          test -d ghidra-stubs
+
 
       - uses: actions/checkout@master
       - name: Set up Python 3.7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Build Package
         run: >-
-          $GHIDRA_ROOT/support/analyzeHeadless /tmp tmp -scriptPath $(pwd) -preScript generate_ghidra_pyi.py ./ ${{ github.ref }}
+          "$GHIDRA_INSTALL_DIR/support/analyzeHeadless" /tmp tmp -scriptPath $(pwd) -preScript generate_ghidra_pyi.py ./ ${{ github.ref }}
 
       - uses: actions/checkout@master
       - name: Set up Python 3.7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,16 +45,13 @@ jobs:
         run: >-
           python -m
           pip install
-          build
+          wheel
           --user
 
       - name: Build a binary wheel and a source tarball
-        run: >-
-          python -m
-          build
-          --sdist
-          --wheel
-          --outdir dist/
+        run: |
+          python setup.py bdist_wheel --universal
+          python setup.py sdist
 
 # TODO: Setup publishing to PyPI by creating package and token and adding to GitHub secrets
 #      - name: Publish distribution 📦 to PyPI

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,19 +22,18 @@ jobs:
           version: "9.2.2"
 
       - name: Prepare Jython Environment
-        run: >-
-          mkvirtualenv -p python2.7 ghidra
+        run: |
           jython_site_packages=~/.local/lib/jython2.7/site-packages
-          mkdir -p $jython_site_packages
-          python2.7 -c "import site; print(site.getusersitepackages()); print(site.getsitepackages()[-1])" > $jython_site_packages/python.pth
+          mkdir -p "$jython_site_packages"
+          python2.7 -c "import site; print(site.getusersitepackages()); print(site.getsitepackages()[-1])" > "$jython_site_packages/python.pth"
           pip2.7 install attrs typing
 
       - name: Build Package
-        run: >-
+        run: |
           "$GHIDRA_INSTALL_DIR/support/analyzeHeadless" /tmp tmp -scriptPath $(pwd) -preScript generate_ghidra_pyi.py ./ ${{ github.ref }}
 
       - name: Check Package Results # analyzeHeadless doesn't return with a nonzero exit code on script failure
-        run: >-
+        run: |
           test -f setup.py
           test -d ghidra-stubs
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,30 +17,27 @@ jobs:
         with:
           java-version: 1.11
 
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "2.7"
+
       - uses: er28-0652/setup-ghidra@master
         with:
           version: "9.2.2"
 
       - name: Prepare Jython Environment
-        run: |
-          jython_site_packages=~/.local/lib/jython2.7/site-packages
-          mkdir -p "$jython_site_packages"
-          python2.7 -c "import site; print(site.getusersitepackages()); print(site.getsitepackages()[-1])" > "$jython_site_packages/python.pth"
-          pip2.7 install attrs typing
+        run:
+          pip2.7 install --target="$GHIDRA_INSTALL_DIR/Ghidra/Features/Python/data/jython-2.7.2/Lib/site-packages" attrs typing
 
       - name: Build Package
         run: |
           "$GHIDRA_INSTALL_DIR/support/analyzeHeadless" /tmp tmp -scriptPath $(pwd) -preScript generate_ghidra_pyi.py ./ ${{ github.ref }}
-
-      - name: Check Package Results # analyzeHeadless doesn't return with a nonzero exit code on script failure
-        run: |
-          test -f setup.py
+          test -f setup.py # check manually, because analyzeHeadless doesn't fail on script failure
           test -d ghidra-stubs
 
-
-      - uses: actions/checkout@master
       - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: 3.7
 
@@ -50,6 +47,7 @@ jobs:
           pip install
           build
           --user
+
       - name: Build a binary wheel and a source tarball
         run: >-
           python -m

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Build Package
         run: >-
-          $GHIDRA_ROOT/support/analyzeHeadless /tmp tmp -scriptPath $(pwd) -preScript generate_ghidra_pyi.py ./
+          $GHIDRA_ROOT/support/analyzeHeadless /tmp tmp -scriptPath $(pwd) -preScript generate_ghidra_pyi.py ./ ${{ github.ref }}
 
       - uses: actions/checkout@master
       - name: Set up Python 3.7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Build Package
         run: |
-          "$GHIDRA_INSTALL_DIR/support/analyzeHeadless" /tmp tmp -scriptPath $(pwd) -preScript generate_ghidra_pyi.py ./ ${{ github.ref }}
+          "$GHIDRA_INSTALL_DIR/support/analyzeHeadless" /tmp tmp -scriptPath $(pwd) -preScript generate_ghidra_pyi.py ./ ${GITHUB_REF#refs/*/}
           test -f setup.py # check manually, because analyzeHeadless doesn't fail on script failure
           test -d ghidra-stubs
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,84 @@
+name: Publish Tagged Commit to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python Package
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+
+      - uses: er28-0652/setup-ghidra@master
+        with:
+          version: "9.2.2"
+
+      - name: Prepare Jython Environment
+        run: >-
+          # Create a virtualenv for Ghidra packages.
+          # It is important to use Python2.7 for this venv!
+          # If you want, you can skip this step and use your default Python installation.
+          mkvirtualenv -p python2.7 ghidra
+
+          # Create Jython's site-pacakges directory.
+          jython_site_packages=~/.local/lib/jython2.7/site-packages
+          mkdir -p $jython_site_packages
+
+          # Create a PTH file to point Jython to Python's site-packages directories.
+          # Again, this has to be Python2.7.
+
+          # Outside a virtualenv, use
+          python2.7 -c "import site; print(site.getusersitepackages()); print(site.getsitepackages()[-1])" > $jython_site_packages/python.pth
+
+          # If using virtualenv, use the following instead
+          python2.7 -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())" > $jython_site_packages/python.pth
+
+
+          # Use pip to install packages for Ghidra
+          pip install attrs typing
+
+      - name: Build Package
+        run: >-
+          $GHIDRA_ROOT/support/analyzeHeadless /tmp tmp -scriptPath $(pwd) -preScript generate_ghidra_pyi.py ./
+
+      - uses: actions/checkout@master
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install pypa/build
+        run: >-
+          python -m
+          pip install
+          build
+          --user
+      - name: Build a binary wheel and a source tarball
+        run: >-
+          python -m
+          build
+          --sdist
+          --wheel
+          --outdir dist/
+
+# TODO: Setup publishing to PyPI by creating package and token and adding to GitHub secrets
+#      - name: Publish distribution 📦 to PyPI
+#        uses: pypa/gh-action-pypi-publish@master
+#        with:
+#          password: ${{ secrets.PYPI_API_TOKEN }}
+
+
+      - name: Release on GitHub
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ./dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *$py.class
 *.pyi
+.idea

--- a/README.md
+++ b/README.md
@@ -6,9 +6,18 @@ Those stub files can later be used in PyCharm to enhance the development experie
 
 You can either use the stubs released [here][latest-release], or follow the instructions below to generate them yourself.
 
-To use the stubs in PyCharm, follow the instructions in [Install, uninstall, and upgrade interpreter paths][interpreter-paths].
 
-### Using The Stubs
+## Using The Stubs
+
+### Installation 
+
+The release contains  [PEP 0561 stub package][pep-0561], which can simply be installed with `pip install ghidra-stubs*.whl`
+into the environment in which the real `ghidra` module is available. Any conformant tool will then use the stub package
+for type analysis purposes.  
+
+If you want to manually add the stub files to PyCharm, follow the instructions in [Install, uninstall, and upgrade interpreter paths][interpreter-paths].
+
+### Usage
 
 Once installed, all you need to do is import the Ghidra modules as usual, and PyCharm will do the rest.
 
@@ -22,10 +31,26 @@ But the `.pyi` gives PyCharm all the information it needs to help you.
 
 ```python
 try:
-    from ghidra_builtins import *
+    from ghidra.ghidra_builtins import *
 except:
     pass
 ```
+
+If you are using [ghidra_bridge](https://github.com/justfoxing/ghidra_bridge) from a Python 3 environment where no real `ghidra` module
+exists you can use a snippet like the following:
+
+```python
+import typing
+if typing.TYPE_CHECKING:
+    import ghidra
+    from ghidra.ghidra_builtins import *
+else:
+    b = ghidra_bridge.GhidraBridge(namespace=globals())
+
+# actual code follows here
+```
+
+`typing.TYPE_CHECKING` is a special value that is always `False` at runtime but `True` during any kind of type checking or completion.
 
 Once done, just code & enjoy.
 

--- a/generate_ghidra_pyi.py
+++ b/generate_ghidra_pyi.py
@@ -4,6 +4,11 @@ from __future__ import print_function
 import type_formatter
 
 import ghidra
+# Make this script work with the stubs in an IDE
+try:
+    from ghidra.ghidra_builtins import *
+except:
+    pass
 from __main__ import askDirectory, askYesNo, getGhidraVersion
 
 from generate_stub_package import generate_package
@@ -35,7 +40,16 @@ def main():
     ghidra_package = type_extractor.Package.from_package(ghidra)
     type_formatter.create_type_hints(pyi_root, ghidra_package)
 
-    generate_package(pyi_root, getGhidraVersion())
+    package_version = "DEV"
+    if isRunningHeadless():
+        # We are running in an headless environment and this might be an automated CI build
+        # so we try getting an extra argument that is supposed to be the git commit tag so the package version is a combination
+        # of the ghidra version and the version of the stub generating code
+        try:
+            package_version = askString("Package version", "Please specify package version")
+        except:
+            pass
+    generate_package(pyi_root, getGhidraVersion(), stub_version=package_version)
 
 if __name__ == '__main__':
     main()

--- a/generate_stub_package.py
+++ b/generate_stub_package.py
@@ -2,7 +2,7 @@ import os
 import shutil
 
 
-def generate_package(pyi_root, ghidra_version):
+def generate_package(pyi_root, ghidra_version, stub_version="DEV"):
 
     setup_code = """
 from setuptools import setup
@@ -19,11 +19,12 @@ def find_stub_files():
     return result
 
 setup(name= 'ghidra-stubs',
-version='{ghidra_version}',
+version='{ghidra_version}_{stub_version}',
 author='Tamir Bahar',
 packages=['ghidra-stubs'],
 package_data={{'ghidra-stubs': find_stub_files()}})
-    """.format(ghidra_version=ghidra_version)
+    """.format(ghidra_version=ghidra_version,
+               stub_version=stub_version)
 
     stub_folder = os.path.join(pyi_root, 'ghidra-stubs')
     os.rename(os.path.join(pyi_root, 'ghidra'), stub_folder)

--- a/type_extractor.py
+++ b/type_extractor.py
@@ -39,6 +39,8 @@ def get_members(obj):
         except java.lang.IllegalArgumentException:
             # Some values cannot be converted to Python types, so we are stuck.
             pass
+        except java.lang.NoClassDefFoundError:
+            pass
 
     # If something is in `__dict__` we want it directly from there.
     # Attribute resolution destroys reflection info when class fields are involved.
@@ -86,10 +88,10 @@ class Overload(object):
         if ctor_for is not None:
             return_type = ctor_for
         else:
-            return_type = reflected_args.data.getReturnType()
+            return_type = reflected_args.method.getReturnType()
 
         return_type = BasicType.from_type(return_type)
-        argument_types = map(BasicType.from_type, reflected_args.data.getParameterTypes())
+        argument_types = map(BasicType.from_type, reflected_args.method.getParameterTypes())
 
         argument_names = get_argument_names(argument_types, docs)
 


### PR DESCRIPTION
GitHub workflow to build a python package as ".whl" when a commit is tagged as `v.*.*.*`, which is then published as a GitHub release.

There is also the relevant snippet for publishing to PyPI, this just needs to be commented in after the token is setup.

Also includes the fix for #9 by @s117