### PR TITLE
add automated and scheduled builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,10 +4,58 @@ on:
   push:
     tags:
       - 'v*.*.*'
-
+  workflow_dispatch:
+    inputs:
+      workflow-ghidra-ver:
+        description: 'Specify Ghidra Version to Build'
+        required: true
+        type: string
+        default: 'latest'
+  schedule:
+    - cron: "0 13 * * 3"
 
 jobs:
+  set-ghidra-version:
+    runs-on: ubuntu-20.04
+    outputs:
+      ghidra-ver: ${{ env.GHIDRA_VER }}
+    steps:
+      - if: github.event_name == 'schedule' || github.event.inputs.workflow-ghidra-ver == 'latest'
+        name: Get Latest Ghidra Version
+        id: get_latest_ghidra_ver
+        uses: pozetroninc/github-action-get-latest-release@v0.6.0
+        with:
+          repository: NationalSecurityAgency/ghidra
+          excludes: prerelease, draft
+      - name: Set Ghidra Version from Latest
+        if: github.event_name == 'schedule' || github.event.inputs.workflow-ghidra-ver == 'latest'
+        id: format_ghidra_ver
+        run: |
+          echo "GHIDRA_VER=$(echo ${{steps.get_latest_ghidra_ver.outputs.release}} | cut -d_ -f2)" >> $GITHUB_ENV
+      - name: Set Ghidra Version from Input
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.workflow-ghidra-ver != 'latest'
+        run: |             
+          echo "GHIDRA_VER=$(echo ${{github.event.inputs.workflow-ghidra-ver}})" >> $GITHUB_ENV
+  check-release:
+    needs:
+      - set-ghidra-version
+    runs-on: ubuntu-20.04
+    outputs:
+      ghidra-ver: ${{ needs.set-ghidra-version.outputs.ghidra-ver }}
+      already-exists: ${{ contains( steps.self.outputs.release, needs.set-ghidra-version.outputs.ghidra-ver) }}
+    steps:
+      - id: self
+        uses: pozetroninc/github-action-get-latest-release@v0.6.0
+        with:
+          repository: ${{ github.repository }}
+      - name: Print Versions and Already Exists
+        run: |
+          echo "${{ needs.set-ghidra-version.outputs.ghidra-ver }}  ${{steps.self.outputs.release }}"
+          echo "already exists ${{ contains( steps.self.outputs.release, needs.set-ghidra-version.outputs.ghidra-ver) }}"
   build-n-publish:
+    needs: 
+      - check-release
+    if: needs.check-release.outputs.already-exists == 'false' || (github.event_name == 'workflow_dispatch' && github.event.inputs.workflow-ghidra-ver != 'latest')
     name: Build and publish Python Package
     runs-on: ubuntu-20.04
     steps:
@@ -24,7 +72,7 @@ jobs:
 
       - uses: er28-0652/setup-ghidra@master
         with:
-          version: "10.1.2"
+          version: "${{ needs.check-release.outputs.ghidra-ver }}"
 
       - name: Prepare Jython Environment
         run:
@@ -64,5 +112,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: ./dist/*
+          tag_name: "v1.0.3-${{ needs.check-release.outputs.ghidra-ver }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -114,10 +114,10 @@ jobs:
           python setup.py sdist
 
 
-      # - name: Publish distribution 📦 to PyPI
-      #   uses: pypa/gh-action-pypi-publish@master
-      #   with:
-      #     password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
 
 
       - name: Release on GitHub

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,10 +4,70 @@ on:
   push:
     tags:
       - 'v*.*.*'
-
+  workflow_dispatch:
+    inputs:
+      workflow-ghidra-ver:
+        description: 'Specify Ghidra Version to Build'
+        required: true
+        type: string
+        default: 'latest'
+  schedule:
+    - cron: "0 13 * * 3"
 
 jobs:
+  set-versions:
+    runs-on: ubuntu-20.04
+    outputs:
+      ghidra-ver: ${{ env.GHIDRA_VER }}
+      pyi-ver: ${{ env.PYI_VER }}
+      pyi-rel-ver: ${{ env.PYI_REL_VER }}
+    steps:
+      - if: github.event_name == 'schedule' || github.event.inputs.workflow-ghidra-ver == 'latest'
+        name: Get Latest Ghidra Version
+        id: get_latest_ghidra_ver
+        uses: pozetroninc/github-action-get-latest-release@v0.6.0
+        with:
+          repository: NationalSecurityAgency/ghidra
+          excludes: prerelease, draft
+      - name: Set Ghidra Version from Latest
+        if: github.event_name == 'schedule' || github.event.inputs.workflow-ghidra-ver == 'latest'
+        id: format_ghidra_ver
+        run: |
+          echo "GHIDRA_VER=$(echo ${{steps.get_latest_ghidra_ver.outputs.release}} | cut -d_ -f2)" >> $GITHUB_ENV
+      - name: Set Ghidra Version from Input
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.workflow-ghidra-ver != 'latest'
+        run: |             
+          echo "GHIDRA_VER=$(echo ${{github.event.inputs.workflow-ghidra-ver}})" >> $GITHUB_ENV
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Get Ghidra Stubs Version
+        id: get_pyi_ver
+        run: |
+          echo "PYI_VER=$(python version.py)" >> $GITHUB_ENV
+      - name: Get Ghidra Stubs Full Release Version
+        id: get_pyi_rel_ver
+        run: |
+          echo "PYI_REL_VER=$GHIDRA_VER.$PYI_VER" >> $GITHUB_ENV
+  check-release:
+    needs:
+      - set-versions
+    runs-on: ubuntu-20.04
+    outputs:      
+      already-exists: ${{ contains( steps.self.outputs.release, needs.set-versions.outputs.pyi-rel-ver ) }}
+    steps:
+      - id: self
+        uses: pozetroninc/github-action-get-latest-release@v0.6.0
+        with:
+          repository: ${{ github.repository }}
+      - name: Print Versions and Already Exists
+        run: |
+          echo "Ghidra ver: ${{ needs.set-versions.outputs.ghidra-ver }} PYI ver: ${{ needs.set-versions.outputs.pyi-ver }} PYI Release: ${{needs.set-versions.outputs.pyi-rel-ver}} Current Release: ${{steps.self.outputs.release }}"
+          echo "already exists ${{ contains( steps.self.outputs.release, needs.set-versions.outputs.pyi-rel-ver ) }}"
   build-n-publish:
+    needs: 
+      - set-versions
+      - check-release
+    if: needs.check-release.outputs.already-exists == 'false' || (github.event_name == 'workflow_dispatch' && github.event.inputs.workflow-ghidra-ver != 'latest')
     name: Build and publish Python Package
     runs-on: ubuntu-20.04
     steps:
@@ -24,7 +84,7 @@ jobs:
 
       - uses: er28-0652/setup-ghidra@master
         with:
-          version: "10.1.2"
+          version: "${{ needs.set-versions.outputs.ghidra-ver }}"
 
       - name: Prepare Jython Environment
         run:
@@ -32,7 +92,7 @@ jobs:
 
       - name: Build Package
         run: |
-          "$GHIDRA_INSTALL_DIR/support/analyzeHeadless" /tmp tmp -scriptPath $(pwd) -preScript generate_ghidra_pyi.py ./ ${GITHUB_REF#refs/*/v}
+          "$GHIDRA_INSTALL_DIR/support/analyzeHeadless" /tmp tmp -scriptPath $(pwd) -preScript generate_ghidra_pyi.py ./ ${{ needs.set-versions.outputs.pyi-ver }}
           test -f setup.py # check manually, because analyzeHeadless doesn't fail on script failure
           test -d ghidra-stubs
 
@@ -54,15 +114,18 @@ jobs:
           python setup.py sdist
 
 
-      - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+      # - name: Publish distribution 📦 to PyPI
+      #   uses: pypa/gh-action-pypi-publish@master
+      #   with:
+      #     password: ${{ secrets.PYPI_API_TOKEN }}
 
 
       - name: Release on GitHub
         uses: softprops/action-gh-release@v1
         with:
           files: ./dist/*
+          tag_name: "v${{ needs.set-versions.outputs.pyi-rel-ver }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+          

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,8 +87,9 @@ jobs:
           version: "${{ needs.set-versions.outputs.ghidra-ver }}"
 
       - name: Prepare Jython Environment
-        run:
-          pip2.7 install --target="$GHIDRA_INSTALL_DIR/Ghidra/Features/Python/data/jython-2.7.2/Lib/site-packages" attrs typing
+        run: | 
+          pip2.7 install --target="$GHIDRA_INSTALL_DIR/Ghidra/Features/Python/data/jython-2.7.2/Lib/site-packages" attrs typing                    
+          pip2.7 install --target="$GHIDRA_INSTALL_DIR/Ghidra/Features/Python/data/jython-2.7.3/Lib/site-packages" attrs typing
 
       - name: Build Package
         run: |

--- a/version.py
+++ b/version.py
@@ -1,0 +1,5 @@
+
+PYI_VERSION = '1.0.4'
+
+if __name__ == '__main__':
+    print(PYI_VERSION)


### PR DESCRIPTION
This pull request is meant to address the issue: https://github.com/VDOO-Connected-Trust/ghidra-pyi-generator/issues/14

I have added two jobs two the workflow that allow a build to be started **on command** (workflow-dispatch). 
![image](https://user-images.githubusercontent.com/3752074/189681904-05ba1e24-3f3a-4434-ad1e-cb9a1f3a3f46.png)
and also on a **schedule**. 

![image](https://user-images.githubusercontent.com/3752074/189682121-e41bbde9-4be2-4dd2-b08c-56d386173950.png)

The workflow has added two additional steps to the original workflow to publish:

1. `set-ghidra-version` - This step will use the Ghidra version provided in the workflow-dispatch, or determine the latest version from the Ghidra repo and use that when 'latest' is specified (also the default).
2. `check-release` - Check release get the versions of the current Ghidra release and checks to see if it has already been released a pyi release. This is simply a convention and relies on the version of Ghidra existing in the release name.

The workflow has been modified to only build if a release with the specified version of Ghidra doesn't exist, or if the version was explicitly specified by the workflow-dispatch.  

One of the unresolved issues with the current implementation is that is the release tag is manually [specified](https://github.com/clearbluejar/ghidra-pyi-generator/blob/automated-scheduled-build/.github/workflows/publish.yml#L115). 


Likely, it would be better to have a file in the repo that contains the `ghidra-pyi-generator` specific version and it could be used as a variable in the line:
```yaml
      - name: Release on GitHub
        uses: softprops/action-gh-release@v1
        with:
          files: ./dist/*
          tag_name: "v1.0.3-${{ needs.check-release.outputs.ghidra-ver }}".   # Change this to <version> variable
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

Another method would be just to release `ghidra-pyi-generator` with version numbers that match Ghidra. 

I have tried this workflow file here: https://github.com/clearbluejar/ghidra-pyi-generator/actions/runs/3038144503 This version ran in my workflow, but recognized there already existed a release of `10.1.5`.
![image](https://user-images.githubusercontent.com/3752074/189686414-1ae4f49b-4d09-412d-83a5-750cd67db889.png)

I run a version of this workflow several times (modified not to publish to pypi). It runs once and week and has [released new versions to match Ghidra](https://github.com/clearbluejar/ghidra-pyi-generator/releases), seemingly working well for the past few months.

Thoughts? How should the version be handled?