### PR TITLE
Update package publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,6 +70,9 @@ jobs:
     if: needs.check-release.outputs.already-exists == 'false' || (github.event_name == 'workflow_dispatch' && github.event.inputs.workflow-ghidra-ver != 'latest')
     name: Build and publish Python Package
     runs-on: ubuntu-20.04
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 1.11
@@ -121,9 +124,7 @@ jobs:
           path: dist
 
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@release/v1
 
 
       - name: Release on GitHub

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,6 +73,8 @@ jobs:
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
+      # Required for publishing a release on GitHub
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 1.11

--- a/generate_stub_package.py
+++ b/generate_stub_package.py
@@ -23,7 +23,10 @@ version='{ghidra_version}.{stub_version}',
 author='Tamir Bahar',
 packages=['ghidra-stubs'],
 url="https://github.com/VDOO-Connected-Trust/ghidra-pyi-generator",
-package_data={{'ghidra-stubs': find_stub_files()}})
+package_data={{'ghidra-stubs': find_stub_files()}},
+long_description=open('README.md').read(),
+long_description_content_type='text/markdown',
+)
     """.format(ghidra_version=ghidra_version,
                stub_version=stub_version)
 


### PR DESCRIPTION
- Use latest release of pypa/gh-action-pypi-publish
- Move from token-based auth to trusted publishing on PyPI
- Publish markdown long_description to fix verification
