### PR TITLE
Importing overload decorator

### DIFF
--- a/type_extractor.py
+++ b/type_extractor.py
@@ -143,7 +143,11 @@ class OverloadSet(object):
 
     @property
     def requires(self):
-        return set().union(*(overload.requires for overload in self.overloads))
+        requirements = set().union(*(overload.requires for overload in self.overloads))
+        if len(self.overloads) > 1:
+            requirements.add(('typing', 'overload'))
+
+        return requirements
 
 
 @attr.s


### PR DESCRIPTION
This fixes a bug where the `overload` decorator was not being imported.

I was seeing an issue in VSCode using type checking with the ghidra stubs. It was not performing type checking correctly on overloaded functions because `overload` was not being imported.