### PR TITLE
Python 3 Types

### DIFF
--- a/basic_type.py
+++ b/basic_type.py
@@ -12,7 +12,7 @@ class BasicType(object):
 
     REPLACEMENTS = {
         'boolean': 'bool',
-        'java.lang.String': 'unicode',
+        'java.lang.String': 'Text',
         'java.lang.Object': 'object',
         'java.math.BigInteger': 'long',
         'long': 'long',
@@ -63,6 +63,8 @@ class BasicType(object):
             requires.add(('typing', 'List'))
         if self.is_iterator:
             requires.add(('typing', 'Iterator'))
+        if self.proper_name == 'Text':
+            requires.add(('typing', 'Text'))
         if '.' in self.proper_name and not self.is_builtin:
             requires.add(self.module)
 

--- a/basic_type.py
+++ b/basic_type.py
@@ -65,6 +65,8 @@ class BasicType(object):
             requires.add(('typing', 'Iterator'))
         if self.proper_name == 'Text':
             requires.add(('typing', 'Text'))
+        if self.proper_name == 'long':
+            requires.add(('py3_compatibility', '*'))
         if '.' in self.proper_name and not self.is_builtin:
             requires.add(self.module)
 

--- a/generate_ghidra_pyi.py
+++ b/generate_ghidra_pyi.py
@@ -17,6 +17,7 @@ import class_loader
 import type_extractor
 import pythonscript_handler
 import helper
+import os
 
 my_globals = globals().copy()
 
@@ -36,6 +37,10 @@ def main():
     class_loader.load_all_classes(prefix='ghidra.')
 
     pythonscript_handler.create_mock(pyi_root, my_globals)
+
+    compatibility_path = os.path.join(pyi_root, 'py3_compatibility.pyi')
+    with open(compatibility_path, 'w') as f:
+        f.write('import sys\nif sys.version_info.major >= 3:\n    long = int\n')
 
     ghidra_package = type_extractor.Package.from_package(ghidra)
     type_formatter.create_type_hints(pyi_root, ghidra_package)


### PR DESCRIPTION
This addresses #28. It using `Text` in place of `unicode` and defines `long` for Python 3.