### PR TITLE
Ghidra 11.2 issues

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,14 +89,7 @@ jobs:
 
       - name: Prepare Jython Environment
         run: |
-          mkdir -p "$GHIDRA_INSTALL_DIR/Ghidra/Features/Python/data/jython-2.7.2/Lib/site-packages"
-          cp -r vendor/* "$GHIDRA_INSTALL_DIR/Ghidra/Features/Python/data/jython-2.7.2/Lib/site-packages/"
-
-          mkdir -p "$GHIDRA_INSTALL_DIR/Ghidra/Features/Python/data/jython-2.7.3/Lib/site-packages"
-          cp -r vendor/* "$GHIDRA_INSTALL_DIR/Ghidra/Features/Python/data/jython-2.7.3/Lib/site-packages/"
-
-          mkdir -p "$GHIDRA_INSTALL_DIR/Ghidra/Features/Ghidra/Features/Jython/lib/Lib/site-packages"
-          cp -r vendor/* "$GHIDRA_INSTALL_DIR/Ghidra/Features/Ghidra/Features/Jython/lib/Lib/site-packages/"
+          "$GHIDRA_INSTALL_DIR/support/analyzeHeadless" /tmp tmp -scriptPath $(pwd) -preScript vendor_packages.py
 
       - name: Build Package
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,7 +81,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11"
+          java-version: "21"
 
       - uses: er28-0652/setup-ghidra@master
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,14 +3,14 @@ name: Publish Tagged Commit to PyPI
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
   workflow_dispatch:
     inputs:
       workflow-ghidra-ver:
-        description: 'Specify Ghidra Version to Build'
+        description: "Specify Ghidra Version to Build"
         required: true
         type: string
-        default: 'latest'
+        default: "latest"
   schedule:
     - cron: "0 13 * * 3"
 
@@ -36,7 +36,7 @@ jobs:
           echo "GHIDRA_VER=$(echo ${{steps.get_latest_ghidra_ver.outputs.release}} | cut -d_ -f2)" >> $GITHUB_ENV
       - name: Set Ghidra Version from Input
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.workflow-ghidra-ver != 'latest'
-        run: |             
+        run: |
           echo "GHIDRA_VER=$(echo ${{github.event.inputs.workflow-ghidra-ver}})" >> $GITHUB_ENV
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -52,7 +52,7 @@ jobs:
     needs:
       - set-versions
     runs-on: ubuntu-20.04
-    outputs:      
+    outputs:
       already-exists: ${{ contains( steps.self.outputs.release, needs.set-versions.outputs.pyi-rel-ver ) }}
     steps:
       - id: self
@@ -64,7 +64,7 @@ jobs:
           echo "Ghidra ver: ${{ needs.set-versions.outputs.ghidra-ver }} PYI ver: ${{ needs.set-versions.outputs.pyi-ver }} PYI Release: ${{needs.set-versions.outputs.pyi-rel-ver}} Current Release: ${{steps.self.outputs.release }}"
           echo "already exists ${{ contains( steps.self.outputs.release, needs.set-versions.outputs.pyi-rel-ver ) }}"
   build-n-publish:
-    needs: 
+    needs:
       - set-versions
       - check-release
     if: needs.check-release.outputs.already-exists == 'false' || (github.event_name == 'workflow_dispatch' && github.event.inputs.workflow-ghidra-ver != 'latest')
@@ -80,21 +80,23 @@ jobs:
       - name: Set up JDK 1.11
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
-          java-version: '11'
-
+          distribution: "temurin"
+          java-version: "11"
 
       - uses: er28-0652/setup-ghidra@master
         with:
           version: "${{ needs.set-versions.outputs.ghidra-ver }}"
 
       - name: Prepare Jython Environment
-        run: | 
+        run: |
           mkdir -p "$GHIDRA_INSTALL_DIR/Ghidra/Features/Python/data/jython-2.7.2/Lib/site-packages"
           cp -r vendor/* "$GHIDRA_INSTALL_DIR/Ghidra/Features/Python/data/jython-2.7.2/Lib/site-packages/"
-          
+
           mkdir -p "$GHIDRA_INSTALL_DIR/Ghidra/Features/Python/data/jython-2.7.3/Lib/site-packages"
           cp -r vendor/* "$GHIDRA_INSTALL_DIR/Ghidra/Features/Python/data/jython-2.7.3/Lib/site-packages/"
+
+          mkdir -p "$GHIDRA_INSTALL_DIR/Ghidra/Features/Ghidra/Features/Jython/lib/Lib/site-packages"
+          cp -r vendor/* "$GHIDRA_INSTALL_DIR/Ghidra/Features/Ghidra/Features/Jython/lib/Lib/site-packages/"
 
       - name: Build Package
         run: |
@@ -128,7 +130,6 @@ jobs:
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
-
       - name: Release on GitHub
         uses: softprops/action-gh-release@v1
         with:
@@ -136,5 +137,3 @@ jobs:
           tag_name: "v${{ needs.set-versions.outputs.pyi-rel-ver }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
-          

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,8 @@ jobs:
       - name: Get site-packages path
         run: |
           echo "import site; print site.getsitepackages()" > /tmp/script.py
-          "$GHIDRA_INSTALL_DIR/support/analyzeHeadless" /tmp tmp -scriptPath /tmp/script.py -preScript /tmp/script.py
+          "$GHIDRA_INSTALL_DIR/support/analyzeHeadless" /tmp tmp -scriptPath $(pwd) -preScript vendor_packages.py
+          find "$GHIDRA_INSTALL_DIR/Ghidra/Features/Ghidra/Features/Jython/lib/Lib/site-packages"
 
       - name: Prepare Jython Environment
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,10 @@ on:
   workflow_dispatch:
     inputs:
       workflow-ghidra-ver:
-        description: 'Specify Ghidra Version to Build'
+        description: "Specify Ghidra Version to Build"
         required: true
         type: string
-        default: 'latest'
+        default: "latest"
 
 jobs:
   set-versions:
@@ -33,7 +33,7 @@ jobs:
           echo "GHIDRA_VER=$(echo ${{steps.get_latest_ghidra_ver.outputs.release}} | cut -d_ -f2)" >> $GITHUB_ENV
       - name: Set Ghidra Version from Input
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.workflow-ghidra-ver != 'latest'
-        run: |             
+        run: |
           echo "GHIDRA_VER=$(echo ${{github.event.inputs.workflow-ghidra-ver}})" >> $GITHUB_ENV
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -56,21 +56,23 @@ jobs:
       - name: Set up JDK 1.11
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
-          java-version: '11'
-
+          distribution: "temurin"
+          java-version: "11"
 
       - uses: er28-0652/setup-ghidra@master
         with:
           version: "${{ needs.set-versions.outputs.ghidra-ver }}"
 
       - name: Prepare Jython Environment
-        run: | 
+        run: |
           mkdir -p "$GHIDRA_INSTALL_DIR/Ghidra/Features/Python/data/jython-2.7.2/Lib/site-packages"
           cp -r vendor/* "$GHIDRA_INSTALL_DIR/Ghidra/Features/Python/data/jython-2.7.2/Lib/site-packages/"
-          
+
           mkdir -p "$GHIDRA_INSTALL_DIR/Ghidra/Features/Python/data/jython-2.7.3/Lib/site-packages"
           cp -r vendor/* "$GHIDRA_INSTALL_DIR/Ghidra/Features/Python/data/jython-2.7.3/Lib/site-packages/"
+
+          mkdir -p "$GHIDRA_INSTALL_DIR/Ghidra/Features/Ghidra/Features/Jython/lib/Lib/site-packages"
+          cp -r vendor/* "$GHIDRA_INSTALL_DIR/Ghidra/Features/Ghidra/Features/Jython/lib/Lib/site-packages/"
 
       - name: Build Package
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,10 @@ jobs:
         with:
           version: "${{ needs.set-versions.outputs.ghidra-ver }}"
 
+      - name: Get site-packages path
+        run: |
+          "$GHIDRA_INSTALL_DIR/support/analyzeHeadless" /tmp tmp -scriptPath <(echo "import site"; echo "print site.getsitepackages()")
+
       - name: Prepare Jython Environment
         run: |
           mkdir -p "$GHIDRA_INSTALL_DIR/Ghidra/Features/Python/data/jython-2.7.2/Lib/site-packages"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,21 +63,9 @@ jobs:
         with:
           version: "${{ needs.set-versions.outputs.ghidra-ver }}"
 
-      - name: Get site-packages path
-        run: |
-          echo "import site; print site.getsitepackages()" > /tmp/script.py
-          "$GHIDRA_INSTALL_DIR/support/analyzeHeadless" /tmp tmp -scriptPath $(pwd) -preScript vendor_packages.py
-          find "$GHIDRA_INSTALL_DIR/Ghidra/Features/Jython/lib/Lib/site-packages/"
       - name: Prepare Jython Environment
         run: |
-          mkdir -p "$GHIDRA_INSTALL_DIR/Ghidra/Features/Python/data/jython-2.7.2/Lib/site-packages"
-          cp -r vendor/* "$GHIDRA_INSTALL_DIR/Ghidra/Features/Python/data/jython-2.7.2/Lib/site-packages/"
-
-          mkdir -p "$GHIDRA_INSTALL_DIR/Ghidra/Features/Python/data/jython-2.7.3/Lib/site-packages"
-          cp -r vendor/* "$GHIDRA_INSTALL_DIR/Ghidra/Features/Python/data/jython-2.7.3/Lib/site-packages/"
-
-          mkdir -p "$GHIDRA_INSTALL_DIR/Ghidra/Features/Jython/lib/Lib/site-packages"
-          cp -r vendor/* "$GHIDRA_INSTALL_DIR/Ghidra/Features/Jython/lib/Lib/site-packages/"
+          "$GHIDRA_INSTALL_DIR/support/analyzeHeadless" /tmp tmp -scriptPath $(pwd) -preScript vendor_packages.py
 
       - name: Build Package
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Get site-packages path
         run: |
-          "$GHIDRA_INSTALL_DIR/support/analyzeHeadless" /tmp tmp -preScript <(echo "import site"; echo "print site.getsitepackages()")
+          "$GHIDRA_INSTALL_DIR/support/analyzeHeadless" /tmp tmp -scriptPath <(echo "import site"; echo "print site.getsitepackages()") -preScript <(echo "import site"; echo "print site.getsitepackages()")
 
       - name: Prepare Jython Environment
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,12 +63,6 @@ jobs:
         with:
           version: "${{ needs.set-versions.outputs.ghidra-ver }}"
 
-      - name: Get site-packages path
-        run: |
-          echo "import site; print site.getsitepackages()" > /tmp/script.py
-          "$GHIDRA_INSTALL_DIR/support/analyzeHeadless" /tmp tmp -scriptPath $(pwd) -preScript vendor_packages.py
-          find "$GHIDRA_INSTALL_DIR/Ghidra/Features/Ghidra/Features/Jython/lib/Lib/site-packages"
-
       - name: Prepare Jython Environment
         run: |
           mkdir -p "$GHIDRA_INSTALL_DIR/Ghidra/Features/Python/data/jython-2.7.2/Lib/site-packages"
@@ -78,7 +72,7 @@ jobs:
           cp -r vendor/* "$GHIDRA_INSTALL_DIR/Ghidra/Features/Python/data/jython-2.7.3/Lib/site-packages/"
 
           mkdir -p "$GHIDRA_INSTALL_DIR/Ghidra/Features/Ghidra/Features/Jython/lib/Lib/site-packages"
-          cp -r vendor/* "$GHIDRA_INSTALL_DIR/Ghidra/Features/Ghidra/Features/Jython/lib/Lib/site-packages/"
+          cp -r vendor/* "$GHIDRA_INSTALL_DIR/Ghidra/Features/Jython/lib/Lib/site-packages/"
 
       - name: Build Package
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,11 @@ jobs:
         with:
           version: "${{ needs.set-versions.outputs.ghidra-ver }}"
 
+      - name: Get site-packages path
+        run: |
+          echo "import site; print site.getsitepackages()" > /tmp/script.py
+          "$GHIDRA_INSTALL_DIR/support/analyzeHeadless" /tmp tmp -scriptPath $(pwd) -preScript vendor_packages.py
+          find "$GHIDRA_INSTALL_DIR/Ghidra/Features/Jython/lib/Lib/site-packages/"
       - name: Prepare Jython Environment
         run: |
           mkdir -p "$GHIDRA_INSTALL_DIR/Ghidra/Features/Python/data/jython-2.7.2/Lib/site-packages"
@@ -71,7 +76,7 @@ jobs:
           mkdir -p "$GHIDRA_INSTALL_DIR/Ghidra/Features/Python/data/jython-2.7.3/Lib/site-packages"
           cp -r vendor/* "$GHIDRA_INSTALL_DIR/Ghidra/Features/Python/data/jython-2.7.3/Lib/site-packages/"
 
-          mkdir -p "$GHIDRA_INSTALL_DIR/Ghidra/Features/Ghidra/Features/Jython/lib/Lib/site-packages"
+          mkdir -p "$GHIDRA_INSTALL_DIR/Ghidra/Features/Jython/lib/Lib/site-packages"
           cp -r vendor/* "$GHIDRA_INSTALL_DIR/Ghidra/Features/Jython/lib/Lib/site-packages/"
 
       - name: Build Package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Get site-packages path
         run: |
-          "$GHIDRA_INSTALL_DIR/support/analyzeHeadless" /tmp tmp -scriptPath <(echo "import site"; echo "print site.getsitepackages()")
+          "$GHIDRA_INSTALL_DIR/support/analyzeHeadless" /tmp tmp -preScript <(echo "import site"; echo "print site.getsitepackages()")
 
       - name: Prepare Jython Environment
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11"
+          java-version: "21"
 
       - uses: er28-0652/setup-ghidra@master
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,8 @@ jobs:
 
       - name: Get site-packages path
         run: |
-          "$GHIDRA_INSTALL_DIR/support/analyzeHeadless" /tmp tmp -scriptPath <(echo "import site"; echo "print site.getsitepackages()") -preScript <(echo "import site"; echo "print site.getsitepackages()")
+          echo "import site; print site.getsitepackages()" > /tmp/script.py
+          "$GHIDRA_INSTALL_DIR/support/analyzeHeadless" /tmp tmp -scriptPath /tmp/script.py -preScript /tmp/script.py
 
       - name: Prepare Jython Environment
         run: |

--- a/pythonscript_handler.py
+++ b/pythonscript_handler.py
@@ -2,7 +2,11 @@ from __future__ import print_function
 
 import os
 
-import ghidra.python.PythonScript
+try:
+    import ghidra.python.PythonScript as PythonScript
+except ImportError:
+    # 11.2 renamed everything to Jython
+    import ghidra.jython.JythonScript as PythonScript
 
 import helper
 import type_extractor
@@ -49,13 +53,13 @@ def is_ghidra_value(value):
 def is_ghidra_method(value):
     return (
         type(value).__name__ == 'instancemethod'
-        and getattr(value, 'im_class', None) == ghidra.python.PythonScript
+        and getattr(value, 'im_class', None) == PythonScript
     )
 
 
 def is_instance_property(name):
     try:
-        getattr(ghidra.python.PythonScript, name)
+        getattr(PythonScript, name)
     except AttributeError as e:
         if e.args[0].startswith('instance attr:'):
             return True

--- a/pythonscript_handler.py
+++ b/pythonscript_handler.py
@@ -2,6 +2,8 @@ from __future__ import print_function
 
 import os
 
+import ghidra 
+
 try:
     import ghidra.python.PythonScript as PythonScript
 except ImportError:

--- a/vendor_packages.py
+++ b/vendor_packages.py
@@ -3,4 +3,4 @@ import shutil
 import os.path
 
 os.system("mkdir -p %s" % (os.path.dirname(site.getsitepackages()[0]), ))
-shutil.copytree(os.path.join(__file__, "..", "vendor"), site.getsitepackages()[0])
+shutil.copytree(os.path.join(os.path.dirname(__file__), "vendor"), site.getsitepackages()[0])

--- a/vendor_packages.py
+++ b/vendor_packages.py
@@ -1,0 +1,6 @@
+import site
+import shutil
+import os.path
+
+os.system("mkdir -p %s" % (site.getsitepackages()[0], ))
+shutil.copytree(os.path.join(__file__, "..", "vendor"), site.getsitepackages()[0])

--- a/vendor_packages.py
+++ b/vendor_packages.py
@@ -2,5 +2,5 @@ import site
 import shutil
 import os.path
 
-os.system("mkdir -p %s" % (site.getsitepackages()[0], ))
+os.system("mkdir -p %s" % (os.path.dirname(site.getsitepackages()[0]), ))
 shutil.copytree(os.path.join(__file__, "..", "vendor"), site.getsitepackages()[0])


### PR DESCRIPTION
Ghidra 11.2 moved some things around:

- The site-packages directory was moved
- Python was renamed to Jython in all important places

This means that we need to adjust both our setup (installing vendored packages) and our code (importing the PythonScript class).

To simplify future updates, vendored package installation now uses a Python script to find the sitepackages and copy the packages over.